### PR TITLE
[f] Upgrade Python version from 3.9 to 3.11

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install Pipenv
         uses: dschep/install-pipenv-action@v1
@@ -31,15 +31,15 @@ jobs:
         uses: actions/cache@v1
         with:
           path: .venv
-          key: pip-3.8-${{ hashFiles('**/Pipfile.lock') }}
+          key: pip-3.11-${{ hashFiles('**/Pipfile.lock') }}
           restore-keys: |
-            pip-3.8-
+            pip-3.11-
             pip-
 
       - name: Install dependencies
         run: pipenv sync
         env:
-          PIPENV_DEFAULT_PYTHON_VERSION: 3.8
+          PIPENV_DEFAULT_PYTHON_VERSION: 3.11
 
       - name: Run scrapers
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9]
+        python-version: [3.11]
 
     steps:
       - uses: actions/checkout@v1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - name: Install Pipenv
         uses: dschep/install-pipenv-action@v1
@@ -37,15 +37,15 @@ jobs:
         uses: actions/cache@v1
         with:
           path: .venv
-          key: pip-3.9-${{ hashFiles('**/Pipfile.lock') }}
+          key: pip-3.11-${{ hashFiles('**/Pipfile.lock') }}
           restore-keys: |
-            pip-3.9-
+            pip-3.11-
             pip-
 
       - name: Install dependencies
         run: pipenv sync
         env:
-          PIPENV_DEFAULT_PYTHON_VERSION: 3.9
+          PIPENV_DEFAULT_PYTHON_VERSION: 3.11
 
       - name: Run scrapers
         run: |

--- a/Pipfile
+++ b/Pipfile
@@ -18,4 +18,4 @@ isort = "*"
 black = "*"
 
 [requires]
-python_version = "3.9"
+python_version = "3.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -5,7 +5,7 @@
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.11"
         },
         "sources": [
             {

--- a/tests/test_sandie_city_council.py
+++ b/tests/test_sandie_city_council.py
@@ -56,8 +56,8 @@ def test_status():
 
 def test_location():
     assert parsed_items[20]["location"] == {
-        "name": "San Diego County Administration Center",
-        "address": "1600 Pacific Hwy., San Diego, California",
+        "name": "San Diego City Administration Center",
+        "address": "202 C Street, San Diego",
     }
 
 


### PR DESCRIPTION
## Description
- Upgrade Python version from 3.9 to 3.11 to resolve the conflict dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated Python version across multiple workflows and the Pipfile to 3.11, enhancing compatibility and performance.

- **Bug Fixes**
	- Adjusted test cases for the `SandieCityCouncilSpider` to reflect accurate location details, ensuring reliable test outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->