### PR TITLE
Update domain: cityscrapers.org -> city-scrapers.org

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -271,7 +271,7 @@
             ],
             "git": "https://github.com/City-Bureau/city-scrapers-core.git",
             "markers": "python_version >= '3.6' and python_version < '4.0'",
-            "ref": "78ccb55766bc445eb2c685bd40a769ce673cb2ee"
+            "ref": "1d06f640cdcfd5986e089379a134f8aec35ce2a9"
         },
         "constantly": {
             "hashes": [


### PR DESCRIPTION
## Summary
- Update data namespace keys: `cityscrapers.org/*` -> `cityscrapers/*`
- Update URLs and User-Agent strings: `cityscrapers.org` -> `city-scrapers.org`
- Update city-scrapers-core to v0.11.0

## Test plan
- [ ] Verify CI passes